### PR TITLE
Add settings-page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { LoginComponent } from './login/login.component';
+import { SettingsComponent } from './settings/settings.component';
 import { AlbumsComponent } from './albums/albums.component';
 import { AlbumComponent } from './album/album.component';
 import { SearchResultComponent } from './search-result/search-result.component';
@@ -9,6 +10,7 @@ import { SearchResultComponent } from './search-result/search-result.component';
   imports: [ RouterModule.forRoot([
     { path: '', component: AlbumsComponent },
     { path: 'login', component: LoginComponent },
+    { path: 'settings', component: SettingsComponent },
     { path: 'album/:id', component: AlbumComponent },
     { path: 'search/:query', component: SearchResultComponent },
     { path: '**', component: AlbumsComponent }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,7 +9,7 @@
         <a class="nav-link text-white p-1" routerLink=""><i class="material-icons mx-3">music_note</i>Playing</a>
         <a class="nav-link text-white p-1" routerLink=""><i class="material-icons mx-3">star</i>Starred</a>
         <a class="nav-link text-white p-1" routerLink=""><i class="material-icons mx-3">playlist_play</i>Playlists</a>
-        <a class="nav-link text-white p-1" routerLink=""><i class="material-icons mx-3">settings</i>Settings</a>
+        <a class="nav-link text-white p-1" routerLink="/settings"><i class="material-icons mx-3">settings</i>Settings</a>
       </nav>
     </div>
 
@@ -17,10 +17,10 @@
   <div id="content" class="p-0 w-100" [class.expand-content]="sideMenuClosed">
 
     <app-top-bar [username]="username" ></app-top-bar>
-    <nav class="navbar bg-secondary p-1">
+    <!-- <nav class="navbar bg-secondary p-1">
       <div class="nav-item">
       </div>
-    </nav>
+    </nav> -->
     <div class="container-fluid m-0 p-0">
       <router-outlet></router-outlet>
     </div>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { AlbumCardComponent } from './shared/component/album-card/album-card.com
 import { AUDIO_PROVIDER, AudioProviderFactory } from './shared/provider/audio.provider';
 import { TopBarComponent } from './top-bar/top-bar.component';
 import { SideMenuService } from './shared/service/side-menu.service';
+import { SettingsComponent } from './settings/settings.component';
 
 @NgModule({
   declarations: [
@@ -43,7 +44,8 @@ import { SideMenuService } from './shared/service/side-menu.service';
     SearchResultComponent,
     SongTableComponent,
     AlbumCardComponent,
-    TopBarComponent
+    TopBarComponent,
+    SettingsComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -1,0 +1,50 @@
+<div class="m-0 p-0 d-flex flex-row h-100">
+
+  <div class="m-0 p-0" id="settings-side-menu">
+    <ul class="nav flex-column d-flex">
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">folder</i>Media folders</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">settings_applications</i>General</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">build</i>Advanced</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">supervisor_account</i>Users</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">play_circle_outline</i>Players</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">perm_media</i>Transcoding</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">wifi_tethering</i>Podcasts</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">share</i>Sharing</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">radio</i>TV & Radio</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">format_paint</i>Theming</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">settings_applications</i>DLNA/UPnP</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link btn-sm px-1 py-2"><i class="material-icons md-18 mr-1">settings_applications</i>Sonos</a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="m-0 p-0 w-100" id="settings-content">
+    <div class="container-fluid m-0 p-0">
+      <!-- <router-outlet></router-outlet> -->
+    </div>
+  </div>
+
+</div>

--- a/src/app/settings/settings.component.scss
+++ b/src/app/settings/settings.component.scss
@@ -1,0 +1,18 @@
+$settings-side-menu-width: 13em;
+$media-controls-height: 56px;
+$top-bar-height: 44px;
+
+#settings-side-menu {
+  width: $settings-side-menu-width;
+  background-color: rgba(0, 0, 0, 0.2);
+  min-height: calc(100vh - #{$media-controls-height} - #{$top-bar-height});
+  .nav-item > .nav-link {
+    border-left: 6px solid transparent;
+    border-radius: 0;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+    &:hover {
+      background-color: rgba(47,123,217, 0.4);
+      border-color: #2F7BD9;
+    }
+  }
+}

--- a/src/app/settings/settings.component.spec.ts
+++ b/src/app/settings/settings.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SettingsComponent } from './settings.component';
+
+describe('SettingsComponent', () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SettingsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.scss']
+})
+export class SettingsComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}


### PR DESCRIPTION
This is the start for the settings page (WIP).

I still I have a few questions on how we should build this :

- Generate child component and load them all together when opening the settings page ? (navigation using tabs)
- Generate child component and load them using something like the router-outlet but only for the "/settings/#components"
- Generate a single settings page and load everything on 1 component ( this might not be a good idea ... )

Should we have a navigation menu on the left or on the top ?

I guess this needs some API changes, we currently only can create users I think ... Waiting airsonic/airsonic#553

We also need to build a service for each settings 'category' I guess or not ?